### PR TITLE
Doc prop inspection graph

### DIFF
--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -134,7 +134,7 @@ ui <- dashboardPage(
         label = "Corpus Article ID",
         value = 1,
         min = 1,
-        max = nrow(model()[['theta']])
+        #max = nrow(model()[['theta']])
       ),
 
       bsTooltip('plotType', "Choose the topic be displayed.",

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -134,7 +134,7 @@ ui <- dashboardPage(
         label = "Corpus Article ID",
         value = 1,
         min = 1,
-        max = nrow(fittedmodel[['theta']])
+        max = nrow(model()[['theta']])
       ),
 
       bsTooltip('plotType', "Choose the topic be displayed.",

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -88,8 +88,9 @@ ui <- dashboardPage(
         "include_doc_theta",
         "Display document index and theta",
         c(
-          "Document #" = 1,
-          "Theta" = 2
+          "Original Document ID" = 1,
+          "Row index" = 2,
+          "Theta" = 3
         ),
         selected = c(1, 2)
       ),
@@ -1189,18 +1190,20 @@ server <- function(input, output, session) {
 
     })
 
-
     # slice and select meta data according to findThoughts indices
-
     topicIndices <- thoughts()$index[[1]][1:100]
     thoughtdf <- stm_data()$out$meta %>%
       slice(topicIndices) %>% select(input$doccol)
 
-    if (1 %in% input$include_doc_theta) {
-      thoughtdf <- cbind(seq.int(nrow(thoughtdf)), thoughtdf)
-      colnames(thoughtdf)[1] <- "Document"
-    }
     if (2 %in% input$include_doc_theta) {
+      thoughtdf <- cbind(seq.int(nrow(thoughtdf)), thoughtdf)
+      colnames(thoughtdf)[1] <- "Row Index"
+    }
+    if (1 %in% input$include_doc_theta) {
+      thoughtdf <- cbind(topicIndices, thoughtdf)
+      colnames(thoughtdf)[1] <- "Original Document ID"
+    }
+    if (3 %in% input$include_doc_theta) {
       thoughtdf$theta <- model()$theta[c(topicIndices),t]
     }
 

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -82,7 +82,20 @@ ui <- dashboardPage(
       bsTooltip(
         'doccol',
         "Select the column of your meta dataframe to be displayed."
-      )
+      ),
+
+      checkboxGroupInput(
+        "include_doc_theta",
+        "Display document index and theta",
+        c(
+          "Document #" = 1,
+          "Theta" = 2
+        ),
+        selected = c(1, 2)
+      ),
+      bsTooltip('include_doc_theta',
+                "Check to include row indices and thetas",
+                placement = "right")
 
     ),
 
@@ -1183,6 +1196,14 @@ server <- function(input, output, session) {
     thoughtdf <- stm_data()$out$meta %>%
       slice(topicIndices) %>% select(input$doccol)
 
+    if (1 %in% input$include_doc_theta) {
+      thoughtdf <- cbind(seq.int(nrow(thoughtdf)), thoughtdf)
+      colnames(thoughtdf)[1] <- "Document"
+    }
+    if (2 %in% input$include_doc_theta) {
+      thoughtdf$theta <- model()$theta[c(topicIndices),t]
+    }
+
     #topicThoughts <- thoughts()$docs[[1]][1:100]
     #thoughtdf <- data.frame(topicThoughts, stringsAsFactors = FALSE)
     #names(thoughtdf) <- " "
@@ -1308,7 +1329,7 @@ server <- function(input, output, session) {
       autoWidth = TRUE,
       scrollX = TRUE,
       info = FALSE,
-      lengthMenu = c(1, 2, 5, 10),
+      lengthMenu = c(1, 5, 10, 50),
       lengthChange = T
     )
   )


### PR DESCRIPTION
added additional plots for a specific document, such that one can see the topic proportions per document, rather than the entire corpus

PS; given that I changed from my main branch, it seems like it already includes the previous changes, so I guess accepting this PR will accept all. I can see if I can re-organize it such that this PR only deals with the additional tab created, let me know 