### PR TITLE
doc graphs and doc inspection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: A 'Shiny' Application for Inspecting Structural Topic Models
 Version: 0.3.0
 Date: 2018-11-23
 Authors@R: c(
-    person("Carsten", "Schwemmer", email = "c.schwem2er@gmail.com", comment = c(ORCID = "0000-0001-9084-946X"), role = c("aut", "cre"))
+    person("Carsten", "Schwemmer", email = "c.schwem2er@gmail.com", comment = c(ORCID = "0000-0001-9084-946X"), role = c("aut", "cre")),
     person("Jonne", "Guyt", email = "j.y.guyt@uva.nl", role = "ctb")
           )
 URL: https://github.com/cschwem2er/stminsights

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,12 @@
 Package: stminsights
 Type: Package
 Title: A 'Shiny' Application for Inspecting Structural Topic Models
-Version: 0.2.3
-Date: 2018-09-22
-Authors@R: person("Carsten", "Schwemmer", email = "c.schwem2er@gmail.com", comment = c(ORCID = "0000-0001-9084-946X"), role = c("aut", "cre"))
+Version: 0.3.0
+Date: 2018-11-23
+Authors@R: c(
+    person("Carsten", "Schwemmer", email = "c.schwem2er@gmail.com", comment = c(ORCID = "0000-0001-9084-946X"), role = c("aut", "cre"))
+    person("Jonne", "Guyt", email = "j.y.guyt@uva.nl", role = "ctb")
+          )
 URL: https://github.com/cschwem2er/stminsights
 BugReports: https://github.com/cschwem2er/stminsights/issues
 Description: This app enables interactive validation, interpretation and visualization of structural topic models from the 'stm' package by Roberts and others (2014) <doi:10.1111/ajps.12103>. It also includes helper functions for model diagnostics and extracting data from effect estimates.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# stminsights 0.3.0
+
+## New features
+
+* representative documents are now searchable
+* representative document table now contains (optional) information on: row id, STM document ID and theta
+* proportions can now be plotted for each individual document using the STM document ID
+* documents can be plotted in a (clickable) 2d scatter plot that shows proportions on two topics simultaneously
+* document information displayed upon clicking scatter plot
+
+## Minor improvements
+
+* popup texts moved such that inputs can be selected more easily
+* default options for document inspection changed
+
 # stminsights 0.2.3
 
 ## Minor improvements

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -591,7 +591,7 @@ ui <- dashboardPage(
         p('This plot shows the proportion for an articles over the selected topics'),
         plotOutput('doc_topic_scatter',
                    height = '600px',
-                   width = "80%",
+                   width = "600px",
                    click = "plot_click",
                    brush = brushOpts(
                      id = "plot_brush"

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -134,7 +134,7 @@ ui <- dashboardPage(
         label = "Corpus Article ID",
         value = 1,
         min = 1,
-        max = nrow(model()[['theta']])
+        #max = nrow(model()[['theta']])
       ),
 
       bsTooltip('plotType', "Choose the topic be displayed.",

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -134,7 +134,7 @@ ui <- dashboardPage(
         label = "Corpus Article ID",
         value = 1,
         min = 1,
-        max = nrow(fittedmodel[['theta']])
+        max = nrow(model()[['theta']])
       ),
 
       bsTooltip('plotType', "Choose the topic be displayed.",

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -88,8 +88,9 @@ ui <- dashboardPage(
         "include_doc_theta",
         "Display document index and theta",
         c(
-          "Document #" = 1,
-          "Theta" = 2
+          "Original Document ID" = 1,
+          "Row index" = 2,
+          "Theta" = 3
         ),
         selected = c(1, 2)
       ),
@@ -1189,18 +1190,20 @@ server <- function(input, output, session) {
 
     })
 
-
     # slice and select meta data according to findThoughts indices
-
     topicIndices <- thoughts()$index[[1]][1:100]
     thoughtdf <- stm_data()$out$meta %>%
       slice(topicIndices) %>% select(input$doccol)
 
-    if (1 %in% input$include_doc_theta) {
-      thoughtdf <- cbind(seq.int(nrow(thoughtdf)), thoughtdf)
-      colnames(thoughtdf)[1] <- "Document"
-    }
     if (2 %in% input$include_doc_theta) {
+      thoughtdf <- cbind(seq.int(nrow(thoughtdf)), thoughtdf)
+      colnames(thoughtdf)[1] <- "Row Index"
+    }
+    if (1 %in% input$include_doc_theta) {
+      thoughtdf <- cbind(topicIndices, thoughtdf)
+      colnames(thoughtdf)[1] <- "Original Document ID"
+    }
+    if (3 %in% input$include_doc_theta) {
       thoughtdf$theta <- model()$theta[c(topicIndices),t]
     }
 

--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -82,7 +82,20 @@ ui <- dashboardPage(
       bsTooltip(
         'doccol',
         "Select the column of your meta dataframe to be displayed."
-      )
+      ),
+
+      checkboxGroupInput(
+        "include_doc_theta",
+        "Display document index and theta",
+        c(
+          "Document #" = 1,
+          "Theta" = 2
+        ),
+        selected = c(1, 2)
+      ),
+      bsTooltip('include_doc_theta',
+                "Check to include row indices and thetas",
+                placement = "right")
 
     ),
 
@@ -1183,6 +1196,14 @@ server <- function(input, output, session) {
     thoughtdf <- stm_data()$out$meta %>%
       slice(topicIndices) %>% select(input$doccol)
 
+    if (1 %in% input$include_doc_theta) {
+      thoughtdf <- cbind(seq.int(nrow(thoughtdf)), thoughtdf)
+      colnames(thoughtdf)[1] <- "Document"
+    }
+    if (2 %in% input$include_doc_theta) {
+      thoughtdf$theta <- model()$theta[c(topicIndices),t]
+    }
+
     #topicThoughts <- thoughts()$docs[[1]][1:100]
     #thoughtdf <- data.frame(topicThoughts, stringsAsFactors = FALSE)
     #names(thoughtdf) <- " "
@@ -1308,7 +1329,7 @@ server <- function(input, output, session) {
       autoWidth = TRUE,
       scrollX = TRUE,
       info = FALSE,
-      lengthMenu = c(1, 2, 5, 10),
+      lengthMenu = c(1, 5, 10, 50),
       lengthChange = T
     )
   )


### PR DESCRIPTION
I've created a new tab that allows for graphs per doc. These graphs are clickable and produce a table with the document information.

I've also made minor improvements over the previous PRs

I think you can just check this one rather than any of the other ones