### PR TITLE
fix document inspection

### DIFF
--- a/inst/app/app.R
+++ b/inst/app/app.R
@@ -1469,7 +1469,7 @@ server <- function(input, output, session) {
     })
 
     # slice and select meta data according to findThoughts indices
-    topicIndices <- thoughts()$index[[1]][1:input$number_articles]
+    topicIndices <- thoughts()$index[[1]]
     thoughtdf <- stm_data()$out$meta %>%
       slice(topicIndices) %>% select(input$doccol)
 


### PR DESCRIPTION
fix #19

The size of dataframe differed due to the fact that in one of the dataframes the dimensions were only adjusted to number of articles requested and not how many were returned as a result of a threshold set for theta.